### PR TITLE
Refactoring of event handling and message passing between Nest, Velox, Channel

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -31,4 +31,16 @@ export enum SendableNestMessageType {
 export interface ChannelMessage {
     Body?: any; // TODO: think about this
     Type?: string;
+    UUID?: string
+}
+export interface ChannelMetaUpdate {
+    Peer?: string;
+    Update?: string;
+}
+
+export interface BeaconEvent {
+    RNM?: RecievableNestMessage
+    SNM?: SendableNestMessage
+    CM?: ChannelMessage
+    CMU?: ChannelMetaUpdate
 }

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,12 @@
+import { ChannelMessage } from "./interfaces";
 import { Velox } from "./velox";
 
 const config = require("./../build/config.json")
 
 const velox = new Velox(config.socketAddr)
+
+velox.onchannelopen((peer) => {
+    const cm: ChannelMessage = {Body:"Hello World"}
+    velox.send(cm)
+    velox.send({Body:peer}, [peer])
+})

--- a/lib/nest.ts
+++ b/lib/nest.ts
@@ -6,10 +6,8 @@ export class Nest {
     private _ws: WebSocket;
     private _active: boolean = false;
     readonly _sockAddr: string = "ws:45.33.74.165:80/nest";
-    private _beacon: EventTarget = new EventTarget;
-        
 
-    constructor(sockAddr?: string) {
+    constructor(sockAddr?: string, RNMHandler?: (message: RecievableNestMessage) => void) {
 
         if (sockAddr !== undefined) {
             this._sockAddr = sockAddr;
@@ -24,11 +22,7 @@ export class Nest {
 
         this._ws.onmessage = (event) => {
             const message: RecievableNestMessage = JSON.parse(event.data);
-            console.log("Recieved: ",message)
-            this._beacon.dispatchEvent(
-                new CustomEvent('recieved', { detail: message })
-            );
-
+            RNMHandler(message)
         };
 
         this._ws.onclose = () => {
@@ -47,18 +41,9 @@ export class Nest {
         return this._active;
     }
 
-    send(data: SendableNestMessage): void {
-        const dta = JSON.stringify(data)
+    SNMProcessor(SNM: SendableNestMessage): void {
+        const dta = JSON.stringify(SNM)
         this._ws.send(dta);
-    }
-
-    // TODO: fix behavior to handle multiple types
-    addNestMessageProcess(type: string, callback: (message: RecievableNestMessage) => void) {
-        const eventCallback = (event: CustomEvent) => {
-            const message: RecievableNestMessage = event.detail
-            callback(message)
-        }
-        this._beacon.addEventListener(type, eventCallback)
     }
 
 }

--- a/lib/velox.ts
+++ b/lib/velox.ts
@@ -1,6 +1,6 @@
 import { Channel } from "./channel";
 import { Nest } from "./nest";
-import { ChannelMessage, RecievableNestMessageType, SendableNestMessage } from "./interfaces";
+import { BeaconEvent, ChannelMessage, ChannelMetaUpdate, RecievableNestMessage, RecievableNestMessageType, SendableNestMessage } from "./interfaces";
 
 export class Velox {
 
@@ -8,72 +8,120 @@ export class Velox {
     private _nest: Nest;
     private _activeChannels: Map<string, Channel>;
     private _beacon: EventTarget = new EventTarget();
-    private _channelNestBridge: (msg: SendableNestMessage) => void 
-    private _messageMap: Map<string, (cm: ChannelMessage) => void>
+    private _messageCallbackMap: Map<string, (cm: ChannelMessage) => void>
     private _defaultMessageCallback: (cm: ChannelMessage) => void
+    private _onChannelOpened: (UUID: string) => void = (UUID: string) => console.log(UUID + " Opened")
+    private _onChannelClosed: (UUID: string) => void = (UUID: string) => console.log(UUID + " Closed")
 
     constructor(socketAddr?: string) {
         this._activeChannels = new Map<string, Channel>();
-        this._messageMap = new Map<string, (cm: ChannelMessage) => void>;
+        this._messageCallbackMap = new Map<string, (cm: ChannelMessage) => void>;
         this._defaultMessageCallback = (cm) => {console.log(cm)}
 
-        this._nest = new Nest(socketAddr);
-
-
-        // function passed to a channel so it can communicate to nest
-        this._channelNestBridge = (msg: SendableNestMessage) => {
-            if (msg.UUID == null) {
-                msg = {...msg, UUID: this._UUID};
-            }
-            this._nest.send(msg)    
+        // channel uses this to emit RCM for velox to route to client
+        const RCMHandler = (message: ChannelMessage) => {
+            this._beacon.dispatchEvent(new CustomEvent("RCM", {detail: {CM: message}}))
         }
 
-        const _veloxConnector = (msg: ChannelMessage) => {
-            const fun = this._messageMap.get(msg.Type)
-            if (fun == undefined) {
-                this._defaultMessageCallback(msg)
-            } else {
-                fun(msg)
-            }
+        // channel uses this to emit SNM for velox to route to nest
+        const SNMHandler = (message: SendableNestMessage) => {
+            this._beacon.dispatchEvent(new CustomEvent("SNM", {detail: {SNM: message}}))  
         }
 
-        this._nest.addNestMessageProcess('recieved', (message) => {
+        // nest uses this to emit RNM for velox to route to channels
+        const RNMHandler = (message: RecievableNestMessage) => {
+            this._beacon.dispatchEvent(new CustomEvent<BeaconEvent>("RNM", {detail: {RNM: message}}))
+        }
+
+        // channel uses this to emit CMU for velox to handle or forward
+        const CMUHandler = (message: ChannelMetaUpdate) => {
+            this._beacon.dispatchEvent(new CustomEvent<BeaconEvent>("CMU", {detail: {CMU: message}}))
+        }
+
+        this._beacon.addEventListener("RNM", (event: CustomEvent<BeaconEvent>) => {
+
+            const message = event.detail.RNM;
+
+            // initial messages are used to configure velox metadata
             if (message.Type == RecievableNestMessageType.Initial) {
                 this._UUID = message.UUID   
+            
+            // the start handshake and offer messages create new channels and binds a listener to them for RNM routing
             } else if (message.Type == RecievableNestMessageType.StartHandshake || message.Type == RecievableNestMessageType.Offer) {
-                this._activeChannels.set(message.UUID, new Channel(this._channelNestBridge, _veloxConnector));
-                this._beacon.addEventListener(message.UUID, (event: CustomEvent) => {
-                    this._activeChannels.get(message.UUID).processNestMessage(event);
+                this._activeChannels.set(message.UUID, 
+                    new Channel(
+                        SNMHandler,
+                        RCMHandler,
+                        CMUHandler));
+                this._beacon.addEventListener(message.UUID, (event: CustomEvent<BeaconEvent>) => {
+                    this._activeChannels.get(message.UUID).RNMProcessor(event.detail.RNM);
                 })
-                this._beacon.dispatchEvent(new CustomEvent(message.UUID, {detail: message}))
+                this._beacon.dispatchEvent(new CustomEvent<BeaconEvent>(message.UUID, {detail: {RNM: message}}))
+            
+            // all other RNM are routed accordingly
             } else if (message.UUID != null) {
-                this._beacon.dispatchEvent(new CustomEvent(message.UUID, {detail: message}))
+                this._beacon.dispatchEvent(new CustomEvent<BeaconEvent>(message.UUID, {detail: {RNM: message}}))
             }
-        }
-        )
+        })
+
+        this._beacon.addEventListener("SNM", (event: CustomEvent<BeaconEvent>) => {
+            const message: SendableNestMessage = event.detail.SNM
+            if (message.UUID == null) {
+                this._nest.SNMProcessor({...message, UUID:this._UUID})
+            } else {
+                this._nest.SNMProcessor(message)
+            }
+        })
+
+        this._beacon.addEventListener("RCM", (event: CustomEvent<BeaconEvent>) => {
+            const message: ChannelMessage = event.detail.CM
+            const f = this._messageCallbackMap.get(message.Type)
+            if (f == undefined) {
+                this._defaultMessageCallback(message)
+            } else {
+                f(message)
+            }
+        })
+
+        this._beacon.addEventListener("CMU", (event: CustomEvent<BeaconEvent>) => {
+            const message: ChannelMetaUpdate = event.detail.CMU
+            if (message.Update == "Opened") {
+                this._onChannelOpened(message.Peer)
+            } else if (message.Update == "Closed") {
+                this._onChannelClosed(message.Peer)
+            }
+        })
+
+        this._nest = new Nest(socketAddr, RNMHandler);
 
     }
 
     registerMessage(type: string, callback: (cm: ChannelMessage) => void) {
-        this._messageMap[type] = callback
+        this._messageCallbackMap[type] = callback
     }
 
     registerDefault(callback: (cm: ChannelMessage) => void) {
         this._defaultMessageCallback = callback
     }
 
-    send(body?: any, type?: string, users?: string[]) {
-        const cm: ChannelMessage = {Type:type, Body:body}
+    onchannelopen(callback: (peer: string) => void) {
+        this._onChannelOpened = callback
+    }
 
+    onchannelclose(callback: (peer: string) => void) {
+        this._onChannelClosed = callback
+    }
+
+    send(cm: ChannelMessage, users?: string[]) {
         // if users is undefined or empty send message globally, otherwise send to specified user(s)
         if (users == undefined || users.length == 0) {
-            for(let [key, channel] of this._activeChannels) {
-                channel.send(cm)
+            for(const [key, channel] of this._activeChannels.entries()) {
+                channel.SCMProcessor(cm)
             }
         } else {
-            for(let user of users) {
-                let channel = this._activeChannels[user]
-                channel.send(cm)
+            for(const user of users) {
+                const channel = this._activeChannels.get(user)
+                channel.SCMProcessor(cm)
             }
         }
     }


### PR DESCRIPTION
This PR contains a major refactoring of the codebase for better event dispatching and handling. All events are based off of the "beacon" event target within the Velox class. nest and channel objects are passed handlers which allow them to dispatch beacon events to the velox objects to handle/properly route. Along with this, some internal functions are now defined as processors as their purpose is to process the message. This naming convention is a bit convoluted and should be revisited in the future.